### PR TITLE
add simple hello world example

### DIFF
--- a/kitchen_sink/hello_world_hostname/panos/.meta-cnc.yaml
+++ b/kitchen_sink/hello_world_hostname/panos/.meta-cnc.yaml
@@ -1,0 +1,36 @@
+name: hostname_change
+# label used for menu selection
+label: Hello World Example (Set hostname)
+
+description: |
+  This skillet demonstrates a very basic Pan-OS configuration change. This allows the user to configure the
+  hostname on a Pan-OS NGFW
+
+# type of skillet (panos or panorama or template or terraform)
+type: panos
+
+# more complex skillets may express a dependency on another skillet that should be loaded before this one.
+# For example, a set of skillets may build off of a single 'golden config' that contains shared configuration
+# As this skillet is very simple, there is no need to build on another one.
+extends:
+
+# Labels allow grouping and type specific options and are generally only used in advanced cases
+labels:
+  collection: Example Skillets
+
+# variables define the things an operator may customize in this skillet. Things like DNS servers, NTP addresses, etc
+# may be customized for each deployment. Each variable will be rendered as a form field in the panhandler application
+variables:
+  - name: FW_NAME
+    description: Firewall hostname
+    default: panos-01
+    type_hint: text
+
+# Snippets is an ordered list of configuration xml fragments that will be pushed to the Pan-OS NGFW. The xpath
+# determines where in the configuration heirarchy the xml fragment will be set. 'file' indicates the name of the file
+# to load and parse. Jinja2 style variables will be variable interpolated using the values of the 'variables' defined
+# in the 'variables' section.
+snippets:
+  - name: device_system
+    xpath: /config/devices/entry[@name='localhost.localdomain']/deviceconfig/system
+    file: device_system.xml

--- a/kitchen_sink/hello_world_hostname/panos/device_system.xml
+++ b/kitchen_sink/hello_world_hostname/panos/device_system.xml
@@ -1,0 +1,1 @@
+<hostname>{{ FW_NAME }}</hostname>


### PR DESCRIPTION
adds a simple hello world example for Pan-OS that only changes the hostname. This is meant to be the very first introduction to .meta-cnc.yaml files, panhandler, and configuration change concepts. It's better to have it in the default skillets than in a separate repository as adding repos is a more advanced topic